### PR TITLE
Adds argument quiet to geodist and geodist_vec to suppress distance check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ inst/WORDLIST
 # compiled object files
 *.o
 *.so
+geodist.Rproj
+src/geodist.dll

--- a/R/geodist-vec.R
+++ b/R/geodist-vec.R
@@ -20,6 +20,8 @@
 #' return \code{n - 1} values.
 #' @param measure One of "haversine" "vincenty", "geodesic", or "cheap"
 #' specifying desired method of geodesic distance calculation; see Notes.
+#' @param quiet If \code{FALSE}, check whether max of calculated distances
+#' is greater than accuracy threshhold and warn.
 #' @return If only \code{(x1, y1)} are passed and \code{sequential = FALSE}, a
 #' square symmetric matrix containing distances between all items in \code{(x1,
 #' y1)}; If only \code{(x1, y1)} are passed and \code{sequential = TRUE}, a
@@ -47,7 +49,7 @@
 #' y2 <- -10 + 20 * runif (2 * n, -0.1, 0.1)
 #' d1 <- geodist_vec (x1, y1, x2, y2) # A 50-by-100 matrix
 geodist_vec <- function (x1, y1, x2, y2, paired = FALSE,
-                         sequential = FALSE, pad = FALSE, measure = "cheap") {
+                         sequential = FALSE, pad = FALSE, measure = "cheap", quiet = FALSE) {
 
     measures <- c ("haversine", "vincenty", "cheap", "geodesic")
     measure <- match.arg (tolower (measure), measures)
@@ -78,7 +80,7 @@ geodist_vec <- function (x1, y1, x2, y2, paired = FALSE,
             res <- geodist_x_vec (x1, y1, measure)
     }
 
-    if (measure == "cheap")
+    if (measure == "cheap" & !quiet)
         check_max_d (res, measure)
 
     return (res)

--- a/R/geodist.R
+++ b/R/geodist.R
@@ -17,6 +17,8 @@
 #' return \code{n - 1} values.
 #' @param measure One of "haversine" "vincenty", "geodesic", or "cheap"
 #' specifying desired method of geodesic distance calculation; see Notes.
+#' @param quiet If \code{FALSE}, check whether max of calculated distances
+#' is greater than accuracy threshhold and warn.
 #' @return If only \code{x} passed and \code{sequential = FALSE}, a square
 #' symmetric matrix containing distances between all items in \code{x}; If only
 #' \code{x} passed and \code{sequential = TRUE}, a vector of sequential
@@ -44,7 +46,7 @@
 #' d2 <- geodist (x, sequential = TRUE, pad = TRUE) # Vector of length 50
 #' d0_2 <- geodist (x, measure = "geodesic") # nanometre-accurate version of d0
 geodist <- function (x, y, paired = FALSE,
-                     sequential = FALSE, pad = FALSE, measure = "cheap") {
+                     sequential = FALSE, pad = FALSE, measure = "cheap", quiet = FALSE) {
 
     measures <- c ("haversine", "vincenty", "cheap", "geodesic")
     measure <- match.arg (tolower (measure), measures)
@@ -79,7 +81,7 @@ geodist <- function (x, y, paired = FALSE,
             res <- geodist_x (x, measure)
     }
 
-    if (measure == "cheap")
+    if (measure == "cheap" & ! quiet)
         check_max_d (res, measure)
 
     return (res)

--- a/man/geodist.Rd
+++ b/man/geodist.Rd
@@ -11,7 +11,8 @@ geodist(
   paired = FALSE,
   sequential = FALSE,
   pad = FALSE,
-  measure = "cheap"
+  measure = "cheap",
+  quiet = FALSE
 )
 }
 \arguments{
@@ -34,6 +35,9 @@ return \code{n - 1} values.}
 
 \item{measure}{One of "haversine" "vincenty", "geodesic", or "cheap"
 specifying desired method of geodesic distance calculation; see Notes.}
+
+\item{quiet}{If \code{FALSE}, check whether max of calculated distances
+is greater than accuracy threshhold and warn.}
 }
 \value{
 If only \code{x} passed and \code{sequential = FALSE}, a square

--- a/man/geodist_vec.Rd
+++ b/man/geodist_vec.Rd
@@ -12,7 +12,8 @@ geodist_vec(
   paired = FALSE,
   sequential = FALSE,
   pad = FALSE,
-  measure = "cheap"
+  measure = "cheap",
+  quiet = FALSE
 )
 }
 \arguments{
@@ -37,6 +38,9 @@ return \code{n - 1} values.}
 
 \item{measure}{One of "haversine" "vincenty", "geodesic", or "cheap"
 specifying desired method of geodesic distance calculation; see Notes.}
+
+\item{quiet}{If \code{FALSE}, check whether max of calculated distances
+is greater than accuracy threshhold and warn.}
 }
 \value{
 If only \code{(x1, y1)} are passed and \code{sequential = FALSE}, a

--- a/tests/testthat/test-geodist.R
+++ b/tests/testthat/test-geodist.R
@@ -176,3 +176,21 @@ test_that ("geodist_vec", {
                    expect_identical (d1, d2)
                }
 })
+
+test_that ("argument quiet for measure cheap works",{
+    x1 <- c(0, 1)
+    y1 <- c(0, 1)
+    x2 <- c(2, 3)
+    y2 <- c(2, 3)
+    x <- cbind ("x" = x1, "y" = y1)
+    y <- cbind ("x" = x2, "y" = y2)
+    
+    expect_message (d1 <- geodist (x, y, paired = TRUE),
+                    "Maximum distance is > 100km")
+    expect_silent (d1 <- geodist (x, y, paired = TRUE, quiet = TRUE))
+    
+    expect_message (d1 <- geodist_vec (x1, y1, x2, y2, paired = TRUE),
+                    "Maximum distance is > 100km")
+    expect_silent (d1 <- geodist_vec (x1, y1, x2, y2, paired = TRUE, quiet = TRUE))
+    
+})


### PR DESCRIPTION
Re: https://github.com/hypertidy/geodist/issues/34

It's sometimes useful to suppress checking and warning about long distances for measure 'cheap` (for example, when checking distances are under a small threshhold.) 

Argument quiet is added to functions `geodist()` and `geodist_vec()` with default value of FALSE to preserve previous behavior.  `quiet = TRUE` skips the call to `check_max_d()`