### PR TITLE
augment 'cheap' warn message with named measures

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -183,7 +183,8 @@ check_max_d <- function (d, measure) {
         message (
             "Maximum distance is > 100km. The 'cheap' measure is ",
             "inaccurate over such\nlarge distances, you'd likely ",
-            "be better using a different 'measure'."
+            "be better using a different 'measure', \n", 
+            "one of 'haversine', 'vincenty', or 'geodesic' "
         )
     }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -184,7 +184,7 @@ check_max_d <- function (d, measure) {
             "Maximum distance is > 100km. The 'cheap' measure is ",
             "inaccurate over such\nlarge distances, you'd likely ",
             "be better using a different 'measure', \n", 
-            "one of 'haversine', 'vincenty', or 'geodesic' "
+            "one of 'haversine', 'vincenty', or 'geodesic'. "
         )
     }
 }


### PR DESCRIPTION
I want the names of the measures in the warning about "cheap" method, so I don't have to look them up. 

I wasn't sure about how to format the 'message()' and added a newline, which was better. 

:)

